### PR TITLE
Change value used in call to unsubscribe

### DIFF
--- a/lib/sql_spy.rb
+++ b/lib/sql_spy.rb
@@ -39,9 +39,9 @@ module SqlSpy
   def self.track
     tracker = Tracker.new
 
-    ActiveSupport::Notifications.subscribe("sql.active_record", tracker)
+    subscriber = ActiveSupport::Notifications.subscribe("sql.active_record", tracker)
     yield
-    ActiveSupport::Notifications.unsubscribe(tracker)
+    ActiveSupport::Notifications.unsubscribe(subscriber)
 
     tracker.queries
   end

--- a/lib/sql_spy.rb
+++ b/lib/sql_spy.rb
@@ -37,11 +37,16 @@ module SqlSpy
   end
 
   def self.track
+
     tracker = Tracker.new
 
     subscriber = ActiveSupport::Notifications.subscribe("sql.active_record", tracker)
-    yield
-    ActiveSupport::Notifications.unsubscribe(subscriber)
+
+    begin
+      yield
+    ensure
+      ActiveSupport::Notifications.unsubscribe(subscriber)
+    end
 
     tracker.queries
   end

--- a/test/sql_spy_test.rb
+++ b/test/sql_spy_test.rb
@@ -144,7 +144,7 @@ class SqlSpyTest < Minitest::Test
     refute query.delete?
   end
 
-  def test_error
+  def test_unsubscribe_on_error
     mock = MiniTest::Mock.new
     mock.expect(:call, true, [Object])
     ActiveSupport::Notifications.stub(:unsubscribe, mock) do

--- a/test/sql_spy_test.rb
+++ b/test/sql_spy_test.rb
@@ -143,4 +143,20 @@ class SqlSpyTest < Minitest::Test
     refute query.update?
     refute query.delete?
   end
+
+  def test_error
+    mock = MiniTest::Mock.new
+    mock.expect(:call, true, [Object])
+    ActiveSupport::Notifications.stub(:unsubscribe, mock) do
+      begin
+        queries = SqlSpy.track do
+          raise "error in block"
+        end
+      rescue => e
+        assert_equal("error in block", e.message)
+      end
+    end
+
+    mock.verify
+  end
 end


### PR DESCRIPTION
It seems like we should be passing the subscriber rather than the callback to the `.unsubscribe` method: https://api.rubyonrails.org/classes/ActiveSupport/Notifications.html#method-c-unsubscribe.